### PR TITLE
Metalog, don't log.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,9 +16,6 @@
 
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [org.slf4j/slf4j-api "1.7.21"]
-                 [org.slf4j/slf4j-simple "1.7.21"]
                  [io.aviso/pretty "0.1.30"]
                  [org.clojure/data.csv "0.1.3"]
                  [org.clojure/data.xml "0.0.8"]

--- a/src/clj_foundation/io.clj
+++ b/src/clj_foundation/io.clj
@@ -22,26 +22,33 @@
        ~@body)))
 
 
+(defn string-output-stream
+  "Create a java.io.PrintStream whose .toString contains the data printed to it."
+  []
+  (let [byte-array-stream (ByteArrayOutputStream.)]
+    (proxy [PrintStream] [byte-array-stream]
+      (toString [] (str byte-array-stream)))))
+
+
 (defmacro with-err-str
   "Anything printed within body to *err* will be returned as a string."
   [& body]
-  `(let [stream#       (ByteArrayOutputStream.)
-         print-stream# (PrintStream. stream#)]
-     (binding [*err* print-stream#]
+  `(let [stream# (string-output-stream)]
+     (binding [*err* stream#]
        ~@body
        (str stream#))))
 
 
-(defmacro print-err
-  "Print to *err* stream"
-  [thing]
-  `(.print *err* ~thing))
+(defmacro print-stream
+  "Print thing to stream"
+  [stream thing]
+  `(.print ~stream ~thing))
 
 
-(defmacro println-err
-  "Println to *err* stream"
-  [thing]
-  `(.println *err* ~thing))
+(defmacro println-stream
+  "Println thing to stream"
+  [stream thing]
+  `(.println ~stream ~thing))
 
 
 (s/defn string-input-stream :- InputStream

--- a/src/clj_foundation/io.clj
+++ b/src/clj_foundation/io.clj
@@ -7,7 +7,7 @@
             [clojure.java.io :as io]
             [clojure.edn :as edn])
 
-  (:import [java.io InputStream File PrintStream ByteArrayInputStream ByteArrayOutputStream]
+  (:import [java.io InputStream File PrintWriter ByteArrayInputStream ByteArrayOutputStream]
            [java.net URI URL Socket]))
 
 
@@ -22,31 +22,33 @@
        ~@body)))
 
 
-(defn string-output-stream
-  "Create a java.io.PrintStream whose .toString contains the data printed to it."
+(defn string-output-writer
+  "Create a java.io.PrintWriter whose .toString contains the data printed to it."
   []
   (let [byte-array-stream (ByteArrayOutputStream.)]
-    (proxy [PrintStream] [byte-array-stream]
-      (toString [] (str byte-array-stream)))))
+    (proxy [PrintWriter] [byte-array-stream]
+      (toString []
+        (.flush this)
+        (str byte-array-stream)))))
 
 
 (defmacro with-err-str
   "Anything printed within body to *err* will be returned as a string."
   [& body]
-  `(let [stream# (string-output-stream)]
+  `(let [stream# (string-output-writer)]
      (binding [*err* stream#]
        ~@body
        (str stream#))))
 
 
-(defmacro print-stream
-  "Print thing to stream"
+(defmacro print-writer
+  "Print thing to writer"
   [stream thing]
   `(.print ~stream ~thing))
 
 
-(defmacro println-stream
-  "Println thing to stream"
+(defmacro println-writer
+  "Println thing to writer"
   [stream thing]
   `(.println ~stream ~thing))
 

--- a/src/clj_foundation/io.clj
+++ b/src/clj_foundation/io.clj
@@ -7,7 +7,7 @@
             [clojure.java.io :as io]
             [clojure.edn :as edn])
 
-  (:import [java.io InputStream File ByteArrayInputStream ByteArrayOutputStream]
+  (:import [java.io InputStream File PrintStream ByteArrayInputStream ByteArrayOutputStream]
            [java.net URI URL Socket]))
 
 
@@ -20,6 +20,28 @@
   `(with-open [stream# (clojure.java.io/writer ~f)]
      (binding [*out* stream#]
        ~@body)))
+
+
+(defmacro with-err-str
+  "Anything printed within body to *err* will be returned as a string."
+  [& body]
+  `(let [stream#       (ByteArrayOutputStream.)
+         print-stream# (PrintStream. stream#)]
+     (binding [*err* print-stream#]
+       ~@body
+       (str stream#))))
+
+
+(defmacro print-err
+  "Print to *err* stream"
+  [thing]
+  `(.print *err* ~thing))
+
+
+(defmacro println-err
+  "Println to *err* stream"
+  [thing]
+  `(.println *err* ~thing))
 
 
 (s/defn string-input-stream :- InputStream

--- a/test/clj_foundation/errors_test.clj
+++ b/test/clj_foundation/errors_test.clj
@@ -87,10 +87,11 @@
   (testing "Can replace the metalogger globally"
     (set-global-metalogger
      (fn [level & more]
-       (apply metalog level "OVERRIDDEN: " more)))
+       (apply metalog level "OVERRIDDEN:" more)))
 
-    (is (str/starts-with? "OVERRIDDEN:" (with-out-str
-                                          (log :warn "Three Blind Locusts"))))
+    (is (str/starts-with? (with-out-str
+                            (log :warn "Three Blind Locusts"))
+                          "OVERRIDDEN:"))
 
     (set-global-metalogger metalog)))
 

--- a/test/clj_foundation/errors_test.clj
+++ b/test/clj_foundation/errors_test.clj
@@ -2,11 +2,13 @@
   (:require [clojure.test :refer :all]
             [schema.core :as s :refer [=> =>*]]
             [clj-foundation.unit-test-common :as common]
-            [clj-foundation.io :as io]
+            [clj-foundation.io :as io :refer [with-err-str]]
             [clj-foundation.errors :refer :all]
             [clj-foundation.data :refer [any?]]
             [clj-foundation.patterns :as p]
-            [clj-foundation.millis :as millis])
+            [clj-foundation.millis :as millis]
+            [clj-foundation.errors :as err]
+            [clojure.string :as str])
   (:import [java.util Date]
            [clojure.lang ExceptionInfo]))
 
@@ -71,6 +73,26 @@
 
     (testing "ex-info :via maps are parsed"
       (is (= 5 (count (seq<- e5)))))))
+
+
+(deftest metalog-test
+  (testing "Warnings and below print to *out*"
+    (is (= "warning\n" (with-out-str
+                         (log :warn "warning")))))
+
+  (testing "Errors and above print to *err*"
+    (is (= "error\n"   (with-err-str
+                         (log :error "error")))))
+
+  (testing "Can replace the metalogger globally"
+    (set-global-metalogger
+     (fn [level & more]
+       (apply metalog level "OVERRIDDEN: " more)))
+
+    (is (str/starts-with? "OVERRIDDEN:" (with-out-str
+                                          (log :warn "Three Blind Locusts"))))
+
+    (set-global-metalogger metalog)))
 
 
 (deftest expect-within-test

--- a/test/clj_foundation/io_test.clj
+++ b/test/clj_foundation/io_test.clj
@@ -14,6 +14,14 @@
 (common/register-fixtures)
 
 
+(deftest with-err-str-test
+  (testing "Printing to *out* doesn't wind up in with-err-str"
+    (is (= "" (with-err-str (print "to *out*")))))
+
+  (testing "Printing to *err* is returned in with-err-str"
+    (is (= "to *err*" (with-err-str (print-err "to *err*"))))))
+
+
 (deftest normalize-file-input-test
   (testing "If a string input references a resource, a resource URL is returned."
     (is (instance? URL (normalize-file-input "_test-config.edn")))

--- a/test/clj_foundation/io_test.clj
+++ b/test/clj_foundation/io_test.clj
@@ -19,8 +19,13 @@
     (is (= "" (with-err-str (print "to *out*")))))
 
   (testing "Printing to *err* is returned in with-err-str"
-    (is (= "to *err*" (with-err-str (print-err "to *err*"))))))
+    (is (= "to *err*" (with-err-str (print-stream *err* "to *err*"))))))
 
+(deftest string-output-stream-test
+  (testing "string-output-stream captures output"
+    (is (= "the output." (let [str-out (string-output-stream)]
+                           (print-stream str-out "the output.")
+                           (.toString str-out))))))
 
 (deftest normalize-file-input-test
   (testing "If a string input references a resource, a resource URL is returned."

--- a/test/clj_foundation/io_test.clj
+++ b/test/clj_foundation/io_test.clj
@@ -19,13 +19,15 @@
     (is (= "" (with-err-str (print "to *out*")))))
 
   (testing "Printing to *err* is returned in with-err-str"
-    (is (= "to *err*" (with-err-str (print-stream *err* "to *err*"))))))
+    (is (= "to *err*" (with-err-str (print-writer *err* "to *err*"))))))
 
-(deftest string-output-stream-test
-  (testing "string-output-stream captures output"
-    (is (= "the output." (let [str-out (string-output-stream)]
-                           (print-stream str-out "the output.")
+
+(deftest string-output-writer-test
+  (testing "string-output-writer captures output"
+    (is (= "the output." (let [str-out (string-output-writer)]
+                           (print-writer str-out "the output.")
                            (.toString str-out))))))
+
 
 (deftest normalize-file-input-test
   (testing "If a string input references a resource, a resource URL is returned."


### PR DESCRIPTION
* Having a logging library dependency here messes up clients; log to a metalogger (that prints to *out*, *err* by default) instead.